### PR TITLE
Migrate to Alpha2 codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # countries-currencies-json
 Json file to easily get currency by country code
+
+Currently using [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) to represent countries.

--- a/currencies.json
+++ b/currencies.json
@@ -18,13 +18,12 @@
   "SY": "LS",
   "GH": "GHC",
   "NG": "NGN",
-  "UAE":"AED",
-  "CHN":"CNY",
+  "CN":"CNY",
   "CA": "CAD",
   "IN": "INR",
   "JP": "JPY",
-  "DEN":"DKK",
-  "GRG":"GEL",
-  "ITY":"EUR",
-  "LBR":"LRD"
+  "DK":"DKK",
+  "GE":"GEL",
+  "IT":"EUR",
+  "LR":"LRD"
 }

--- a/currencies.json
+++ b/currencies.json
@@ -18,6 +18,7 @@
   "SY": "LS",
   "GH": "GHC",
   "NG": "NGN",
+  "AE": "AED",
   "CN":"CNY",
   "CA": "CAD",
   "IN": "INR",


### PR DESCRIPTION
Hello! Since the .json file is currently a mix of Alpha2 (two characters) and Alpha3 (three characters) country codes, I propose to use Alpha2 exclusively for consistency between codes.

[This Wiki article](https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes) shows the difference between the two.

Cheers!